### PR TITLE
Add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "ember build",
     "test": "ember test"
   },
-  "repository": "",
+  "repository": "https://github.com/diploidgenomics/ember-cli-cors",
   "engines": {
     "node": ">= 0.10.0"
   },


### PR DESCRIPTION
This prevents npm from displaying warnings
